### PR TITLE
Bugfix: Explicitly cast linestring in function `.connection_summary` …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hereR
 Type: Package
 Title: 'sf'-Based Interface to the 'HERE' REST APIs
-Version: 0.8.1
+Version: 0.8.1.9000
 Authors@R: c(
     person("Merlin", "Unterfinger", role = c("aut", "cre"), email = "info@munterfinger.ch", comment = c(ORCID = "0000-0003-2020-2366")),
     person("Daniel", "Possenriede", role = "ctb", comment = c(ORCID = "0000-0002-6738-9845")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# version 0.8.1.9000
+
+* Bugfix: Explicitly cast linestring in function `.connection_summary` to avoid error in `CPL_geos_union` (@panhypersebastos).
+
 # version 0.8.1
 
 * Adjust URLs to GitHub account due to renaming munterfinger to @munterfi.

--- a/R/connection.R
+++ b/R/connection.R
@@ -274,7 +274,7 @@ connection <- function(origin, destination, datetime = Sys.time(),
     providers = paste(stats::na.exclude(provider), collapse = ", "),
     distance = sum(distance),
     duration = sum(duration),
-    geometry = suppressMessages(sf::st_union(geometry))
+    geometry = suppressMessages(sf::st_union(sf::st_cast(geometry, "LINESTRING")))
   ), by = list(id, rank)]
   return(summary)
 }


### PR DESCRIPTION
…to avoid error in `CPL_geos_union`