### PR TITLE
Connection returns an empty data table when some fields are NULL (since data.table 1.15.0)

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -216,24 +216,16 @@ connection <- function(origin, destination, datetime = Sys.time(),
                 rank = rank,
                 section = seq_len(nrow(sec)),
                 departure = sec$departure$time,
-                origin = vapply(
-                  sec$departure$place$name,
-                  function(x) if (is.na(x)) "ORIG" else x,
-                  character(1)
-                ),
+                origin = sec$departure$place$name %||% "ORIG",
                 arrival = sec$arrival$time,
-                destination = vapply(
-                  sec$arrival$place$name,
-                  function(x) if (is.na(x)) "DEST" else x,
-                  character(1)
-                ),
-                mode = sec$transport$mode,
-                category = sec$transport$category,
-                vehicle = sec$transport$name,
-                provider = sec$agency$name,
-                direction = sec$transport$headsign,
-                distance = sec$travelSummary$length,
-                duration = sec$travelSummary$duration,
+                destination = sec$arrival$place$name %||% "DEST",
+                mode = sec$transport$mode %||% NA_character_,
+                category = sec$transport$category %||% NA_character_,
+                vehicle = sec$transport$name %||% NA_character_,
+                provider = sec$agency$name %||% NA_character_,
+                direction = sec$transport$headsign %||% NA_character_,
+                distance = sec$travelSummary$length %||% NA_real_,
+                duration = sec$travelSummary$duration %||% NA_real_,
                 geometry = sec$polyline
               )
             }),
@@ -277,4 +269,9 @@ connection <- function(origin, destination, datetime = Sys.time(),
     geometry = suppressMessages(sf::st_union(sf::st_cast(geometry, "LINESTRING")))
   ), by = list(id, rank)]
   return(summary)
+}
+
+
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
 }


### PR DESCRIPTION
data.table no longer fills in rows with NA when some of the values are NULL since 1.15.0.
This broke connection:
* empty tables are returned 
* Leads to flexpolyline::decode_sf being called on a NULL
* returning "Invalid format version"

This pull fixes that by recreating the rlang operator %||% and using it to avoid nulls.
Maybe not exactly your philosophy, and maybe needs to be replicated in other places, but a first step towards resolution :)