### PR TITLE
Remove consumption model in route requests for bicycle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # version 1.0.1
 
 - Prevent the consumption model from being added to the request when the transport mode is set to `"pedestrian"` in `isoline()` and `route()` functions (closes [#167](https://github.com/munterfi/hereR/issues/167)).
-- Adjust the rate limit in `route()` to 7 requests per second (RPS). Although HERE's documentation specifies a 10 RPS limit, it has been lowered to 7 RPS to avoid frequent 429 "Too Many Requests" errors.
+- Adjust the rate limit in `route()` to 7 requests per second (RPS). Although HERE's documentation specifies a 10 RPS limit, it has been lowered to 5 RPS to avoid frequent 429 "Too Many Requests" errors.
 
 # version 1.0.0
 

--- a/R/route.R
+++ b/R/route.R
@@ -132,7 +132,7 @@ route <- function(origin, destination, datetime = Sys.time(), arrival = FALSE,
     )
   }
 
-  if (transport_mode != "pedestrian") {
+  if (!(transport_mode %in% c("pedestrian", "bicycle"))) {
     # Add consumption model if specified, otherwise set to default electric vehicle
     if (is.null(consumption_model)) {
       url <- paste0(
@@ -179,7 +179,7 @@ route <- function(origin, destination, datetime = Sys.time(), arrival = FALSE,
   # Request and get content
   data <- .async_request(
     url = url,
-    rps = 7
+    rps = 5
   )
   if (length(data) == 0) {
     return(NULL)


### PR DESCRIPTION
- Further decrease RPS from 7 to 5, due to status 429.