### PR TITLE
feat: allow setting speed limit in isoline and route requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Replace deprecated `with_mock()` from **testthat** with `with_mocked_bindings()` in all test cases (closes [#174](https://github.com/munterfi/hereR/issues/174)).
 - Updated the test coverage GitHub Action workflow to use `actions/upload-artifact@v4`, fixing a deprecation issue.
 - Add support for configuring speed limits in `isoline()` and `route()` requests via the `speed_limit` parameter. This sets `&pedestrian[speed]=<LIMIT>` for pedestrian mode and `&vehicle[speedCap]=<LIMIT>` for vehicle-based modes in API requests (refs [#175](https://github.com/munterfi/hereR/issues/175)).
+- Expand transport mode support in `isoline()` routing by enabling `"bicycle"`, `"scooter"`, `"taxi"`, `"bus"`, and `"privateBus"`, in line with newly available API options.
 
 # version 1.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Replace deprecated `with_mock()` from **testthat** with `with_mocked_bindings()` in all test cases (closes [#174](https://github.com/munterfi/hereR/issues/174)).
 - Updated the test coverage GitHub Action workflow to use `actions/upload-artifact@v4`, fixing a deprecation issue.
+- Add support for configuring speed limits in `isoline()` and `route()` requests via the `speed_limit` parameter. This sets `&pedestrian[speed]=<LIMIT>` for pedestrian mode and `&vehicle[speedCap]=<LIMIT>` for vehicle-based modes in API requests (refs [#175](https://github.com/munterfi/hereR/issues/175)).
 
 # version 1.0.1
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -113,12 +113,7 @@ qualified_keys <- c(
   modes <- c(
     "car", "truck", "pedestrian", "bicycle", "scooter", "taxi", "bus", "privateBus"
   )
-  if (request == "isoline") {
-    modes <- modes[c(1, 2, 3)]
-    if (!transport_mode %in% modes) {
-      stop(.stop_print_transport_modes(mode = transport_mode, modes = modes, request = request))
-    }
-  } else if (request == "route" || request == "matrix") {
+  if (request == "route" || request == "matrix" || request == "isoline") {
     if (!transport_mode %in% modes) {
       stop(.stop_print_transport_modes(mode = transport_mode, modes = modes, request = request))
     }

--- a/R/isoline.R
+++ b/R/isoline.R
@@ -14,7 +14,7 @@
 #' @param range_type character, unit of the isolines: \code{"distance"}, \code{"time"} or \code{"consumption"}.
 #' @param routing_mode character, set the routing mode: \code{"fast"} or \code{"short"}.
 #' @param transport_mode character, set the transport mode: \code{"car"}, \code{"pedestrian"} or \code{"truck"}.
-#' @param speed_limit numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.
+#' @param speed_limit numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (e.g. \code{"car"} or \code{"truck"}), the value must be between 1 and 70 m/s.
 #' @param traffic boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.
 #' @param optimize, character, specifies how isoline calculation is optimized: \code{"balanced"}, \code{"quality"} or \code{"performance"} (\code{default = "balanced"}).
 #' @param consumption_model character, specify the consumption model of the vehicle (\code{default = NULL} an average electric car is set).
@@ -114,7 +114,7 @@ isoline <- function(poi, datetime = Sys.time(), arrival = FALSE,
     optimize
   )
 
-  if (transport_mode != "pedestrian") {
+  if (!(transport_mode %in% c("pedestrian", "bicycle"))) {
     # Add consumption model if specified, otherwise set to default electric vehicle
     if (is.null(consumption_model)) {
       url <- paste0(

--- a/R/isoline.R
+++ b/R/isoline.R
@@ -1,6 +1,6 @@
 #' HERE Isoline Routing API: Calculate Isoline
 #'
-#' Calcuates isolines (\code{POLYGON} or \code{MULTIPOLYGON}) using the HERE 'Isoline Routing' API
+#' Calculates isolines (\code{POLYGON} or \code{MULTIPOLYGON}) using the HERE 'Isoline Routing' API
 #' that connect the end points of all routes leaving from defined centers (POIs) with either
 #' a specified length, a specified travel time or consumption (only the default E-car available).
 #'
@@ -14,6 +14,7 @@
 #' @param range_type character, unit of the isolines: \code{"distance"}, \code{"time"} or \code{"consumption"}.
 #' @param routing_mode character, set the routing mode: \code{"fast"} or \code{"short"}.
 #' @param transport_mode character, set the transport mode: \code{"car"}, \code{"pedestrian"} or \code{"truck"}.
+#' @param speed_limit numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.
 #' @param traffic boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.
 #' @param optimize, character, specifies how isoline calculation is optimized: \code{"balanced"}, \code{"quality"} or \code{"performance"} (\code{default = "balanced"}).
 #' @param consumption_model character, specify the consumption model of the vehicle (\code{default = NULL} an average electric car is set).
@@ -37,7 +38,7 @@
 isoline <- function(poi, datetime = Sys.time(), arrival = FALSE,
                     range = seq(5, 30, 5) * 60, range_type = "time",
                     routing_mode = "fast", transport_mode = "car",
-                    traffic = TRUE, optimize = "balanced",
+                    speed_limit = 0, traffic = TRUE, optimize = "balanced",
                     consumption_model = NULL, aggregate = FALSE,
                     url_only = FALSE) {
   # Checks
@@ -46,6 +47,7 @@ isoline <- function(poi, datetime = Sys.time(), arrival = FALSE,
   .check_range_type(range_type)
   .check_routing_mode(routing_mode)
   .check_transport_mode(transport_mode, request = "isoline")
+  .check_numeric_range(speed_limit, 0, Inf)
   .check_optimize(optimize)
   .check_boolean(traffic)
   .check_boolean(arrival)
@@ -90,6 +92,11 @@ isoline <- function(poi, datetime = Sys.time(), arrival = FALSE,
 
   # Add transport mode
   url <- .add_transport_mode(url, transport_mode)
+
+  # Add speed limit
+  if (speed_limit > 0) {
+    url <- .add_speed_limit(url, speed_limit, transport_mode)
+  }
 
   # Add range and range type
   url <- paste0(

--- a/R/route.R
+++ b/R/route.R
@@ -15,7 +15,7 @@
 #' @param arrival boolean, calculate routes for arrival at the defined time (\code{default = FALSE})?
 #' @param results numeric, maximum number of suggested routes (Valid range: 1 and 7).
 #' @param routing_mode character, set the routing type: \code{"fast"} or \code{"short"} (\code{default = "fast"}).
-#' @param speed_limit numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.
+#' @param speed_limit numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (e.g. \code{"car"} or \code{"truck"}), the value must be between 1 and 70 m/s.
 #' @param transport_mode character, set the transport mode: \code{"car"}, \code{"truck"}, \code{"pedestrian"}, \code{"bicycle"}, \code{"scooter"}, \code{"taxi"}, \code{"bus"} or \code{"privateBus"} (\code{default = "car"}).
 #' @param traffic boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.
 #' @param avoid_area, \code{sf} object, area (only bounding box is taken) to avoid in routes (\code{default = NULL}).

--- a/R/route.R
+++ b/R/route.R
@@ -15,6 +15,7 @@
 #' @param arrival boolean, calculate routes for arrival at the defined time (\code{default = FALSE})?
 #' @param results numeric, maximum number of suggested routes (Valid range: 1 and 7).
 #' @param routing_mode character, set the routing type: \code{"fast"} or \code{"short"} (\code{default = "fast"}).
+#' @param speed_limit numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.
 #' @param transport_mode character, set the transport mode: \code{"car"}, \code{"truck"}, \code{"pedestrian"}, \code{"bicycle"}, \code{"scooter"}, \code{"taxi"}, \code{"bus"} or \code{"privateBus"} (\code{default = "car"}).
 #' @param traffic boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.
 #' @param avoid_area, \code{sf} object, area (only bounding box is taken) to avoid in routes (\code{default = NULL}).
@@ -50,8 +51,9 @@
 #' )
 route <- function(origin, destination, datetime = Sys.time(), arrival = FALSE,
                   results = 1, routing_mode = "fast", transport_mode = "car",
-                  traffic = TRUE, avoid_area = NULL, avoid_feature = NULL,
-                  consumption_model = NULL, vignettes = TRUE, url_only = FALSE) {
+                  speed_limit = 0, traffic = TRUE, avoid_area = NULL,
+                  avoid_feature = NULL, consumption_model = NULL,
+                  vignettes = TRUE, url_only = FALSE) {
   # Checks
   .check_points(origin)
   .check_points(destination)
@@ -61,6 +63,7 @@ route <- function(origin, destination, datetime = Sys.time(), arrival = FALSE,
   .check_numeric_range(results, 1, 7)
   .check_routing_mode(routing_mode)
   .check_transport_mode(transport_mode, request = "route")
+  .check_numeric_range(speed_limit, 0, Inf)
   .check_boolean(traffic)
   .check_polygon(avoid_area)
   .check_character(avoid_feature)
@@ -103,6 +106,11 @@ route <- function(origin, destination, datetime = Sys.time(), arrival = FALSE,
 
   # Add transport mode
   url <- .add_transport_mode(url, transport_mode)
+
+  # Add speed limit
+  if (speed_limit > 0) {
+    url <- .add_speed_limit(url, speed_limit, transport_mode)
+  }
 
   # Add alternatives (results minus 1)
   url <- paste0(

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,7 @@
   }
 
   if (transport_mode == "bicycle") {
-    warning("Setting a 'speed_limit' with transport mode 'bicycle' is not supported, omitting...")
+    warning("Setting a 'speed_limit' with transport mode 'bicycle' is not supported, omitting...\n")
     return(url)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,13 +21,18 @@
 .add_speed_limit <- function(url, speed_limit, transport_mode) {
   if (is.null(speed_limit)) {
     return(url)
-  } else {
-    paste0(
-      url,
-      ifelse(transport_mode == "pedestrian", "&pedestrian[speed]=", "&vehicle[speedCap]="),
-      speed_limit
-    )
   }
+
+  if (transport_mode == "bicycle") {
+    warning("Setting a 'speed_limit' with transport mode 'bicycle' is not supported, omitting...")
+    return(url)
+  }
+
+  paste0(
+    url,
+    ifelse(transport_mode == "pedestrian", "&pedestrian[speed]=", "&vehicle[speedCap]="),
+    speed_limit
+  )
 }
 
 .add_bbox <- function(url, aoi) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,6 +18,18 @@
   )
 }
 
+.add_speed_limit <- function(url, speed_limit, transport_mode) {
+  if (is.null(speed_limit)) {
+    return(url)
+  } else {
+    paste0(
+      url,
+      ifelse(transport_mode == "pedestrian", "&pedestrian[speed]=", "&vehicle[speedCap]="),
+      speed_limit
+    )
+  }
+}
+
 .add_bbox <- function(url, aoi) {
   bbox <- vapply(sf::st_geometry(aoi), sf::st_bbox, numeric(4))
   .check_bbox(bbox)

--- a/man/isoline.Rd
+++ b/man/isoline.Rd
@@ -35,7 +35,7 @@ isoline(
 
 \item{transport_mode}{character, set the transport mode: \code{"car"}, \code{"pedestrian"} or \code{"truck"}.}
 
-\item{speed_limit}{numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.}
+\item{speed_limit}{numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (e.g. \code{"car"} or \code{"truck"}), the value must be between 1 and 70 m/s.}
 
 \item{traffic}{boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.}
 

--- a/man/isoline.Rd
+++ b/man/isoline.Rd
@@ -12,6 +12,7 @@ isoline(
   range_type = "time",
   routing_mode = "fast",
   transport_mode = "car",
+  speed_limit = 0,
   traffic = TRUE,
   optimize = "balanced",
   consumption_model = NULL,
@@ -34,6 +35,8 @@ isoline(
 
 \item{transport_mode}{character, set the transport mode: \code{"car"}, \code{"pedestrian"} or \code{"truck"}.}
 
+\item{speed_limit}{numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.}
+
 \item{traffic}{boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.}
 
 \item{optimize, }{character, specifies how isoline calculation is optimized: \code{"balanced"}, \code{"quality"} or \code{"performance"} (\code{default = "balanced"}).}
@@ -48,7 +51,7 @@ isoline(
 An \code{sf} object containing the requested isolines.
 }
 \description{
-Calcuates isolines (\code{POLYGON} or \code{MULTIPOLYGON}) using the HERE 'Isoline Routing' API
+Calculates isolines (\code{POLYGON} or \code{MULTIPOLYGON}) using the HERE 'Isoline Routing' API
 that connect the end points of all routes leaving from defined centers (POIs) with either
 a specified length, a specified travel time or consumption (only the default E-car available).
 }

--- a/man/route.Rd
+++ b/man/route.Rd
@@ -36,7 +36,7 @@ route(
 
 \item{transport_mode}{character, set the transport mode: \code{"car"}, \code{"truck"}, \code{"pedestrian"}, \code{"bicycle"}, \code{"scooter"}, \code{"taxi"}, \code{"bus"} or \code{"privateBus"} (\code{default = "car"}).}
 
-\item{speed_limit}{numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.}
+\item{speed_limit}{numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (e.g. \code{"car"} or \code{"truck"}), the value must be between 1 and 70 m/s.}
 
 \item{traffic}{boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.}
 

--- a/man/route.Rd
+++ b/man/route.Rd
@@ -12,6 +12,7 @@ route(
   results = 1,
   routing_mode = "fast",
   transport_mode = "car",
+  speed_limit = 0,
   traffic = TRUE,
   avoid_area = NULL,
   avoid_feature = NULL,
@@ -34,6 +35,8 @@ route(
 \item{routing_mode}{character, set the routing type: \code{"fast"} or \code{"short"} (\code{default = "fast"}).}
 
 \item{transport_mode}{character, set the transport mode: \code{"car"}, \code{"truck"}, \code{"pedestrian"}, \code{"bicycle"}, \code{"scooter"}, \code{"taxi"}, \code{"bus"} or \code{"privateBus"} (\code{default = "car"}).}
+
+\item{speed_limit}{numeric, sets the maximum allowed speed in meters per second (\code{default = 0}). For \code{"pedestrian"} mode, the value must be between 0.5 and 2 m/s. For vehicle-based modes (\code{"car"} and \code{"truck"}), the value must be between 1 and 70 m/s.}
 
 \item{traffic}{boolean, use real-time traffic or prediction in routing (\code{default = TRUE})? If no traffic is selected, the \code{datetime} is set to \code{"any"} and the request is processed independently from time.}
 


### PR DESCRIPTION
The speed limit is now configurable via the `speed_limit` parameter, setting `&pedestrian[speed]=<LIMIT>` for pedestrian mode or `&vehicle[speedCap]=<LIMIT>` for vehicle-based modes in API requests.

Enable additional transport modes in `isoline()` routing, including `"bicycle"`, `"scooter"`, `"taxi"`, `"bus"`, and `"privateBus"`, aligning with newly available API options.

Note: The `speed_limit` parameter is not supported when using the `"bicycle"` transport mode.

Refs: #175